### PR TITLE
[Feature] Sink supports LZ4 compression with json format

### DIFF
--- a/src/main/java/com/starrocks/connector/kafka/StarRocksSinkConnectorConfig.java
+++ b/src/main/java/com/starrocks/connector/kafka/StarRocksSinkConnectorConfig.java
@@ -141,7 +141,7 @@ public class StarRocksSinkConnectorConfig {
                         STARROCKS_PASSWORD,
                         ConfigDef.Type.STRING,
                         null,
-                        new ConfigDef.NonEmptyString(),
+                        null,
                         ConfigDef.Importance.HIGH,
                         "starrocks password",
                         CONFIG_GROUP_1,

--- a/src/main/java/com/starrocks/connector/kafka/StarRocksSinkTask.java
+++ b/src/main/java/com/starrocks/connector/kafka/StarRocksSinkTask.java
@@ -150,14 +150,16 @@ public class StarRocksSinkTask extends SinkTask  {
         if (!props.containsKey(StarRocksSinkConnectorConfig.SINK_FORMAT)) {
             props.put(StarRocksSinkConnectorConfig.SINK_FORMAT, "json");
         }
-        LOG.info("Starrocks sink type is " + sinkType.toString());
+        parseSinkStreamLoadProperties();
+        LOG.info("Starrocks sink type is {}, stream load properties: {}", sinkType, streamLoadProps);
         // The Stream SDK must force the table name, which we set to _sr_default_table.
         // _sr_default_table will not be used.
         StreamLoadTableProperties.Builder defaultTablePropertiesBuilder = StreamLoadTableProperties.builder()
                 .database(database)
                 .table("_sr_default_table")
                 .streamLoadDataFormat(dataFormat)
-                .chunkLimit(getChunkLimit());
+                .chunkLimit(getChunkLimit())
+                .addCommonProperties(streamLoadProps);
         String buffMaxbytesStr = props.getOrDefault(StarRocksSinkConnectorConfig.BUFFERFLUSH_MAXBYTES, "67108864");
         buffMaxbytes = Long.parseLong(buffMaxbytesStr);
         String connectTimeoutmsStr = props.getOrDefault(StarRocksSinkConnectorConfig.CONNECT_TIMEOUTMS, "100");
@@ -166,7 +168,6 @@ public class StarRocksSinkTask extends SinkTask  {
         String password = props.get(StarRocksSinkConnectorConfig.STARROCKS_PASSWORD);
         String bufferFlushIntervalStr = props.getOrDefault(StarRocksSinkConnectorConfig.BUFFERFLUSH_INTERVALMS, "1000");
         bufferFlushInterval = Long.parseLong(bufferFlushIntervalStr);
-        parseSinkStreamLoadProperties();
         StreamLoadProperties.Builder builder = StreamLoadProperties.builder()
                 .loadUrls(loadUrl)
                 .defaultTableProperties(defaultTablePropertiesBuilder.build())


### PR DESCRIPTION
After StarRocks supports lz4 compression for stream load json format in https://github.com/StarRocks/starrocks/pull/43732, the connector can compress the json data before sending to StarRocks which will reduce the network traffic significantly. In the test to load clickbench data to starrocks, the compression ratio can be ~8, and the load performance has a 3.64% degradation which is acceptable. This RP depends on [stream-load-sdk](https://github.com/StarRocks/starrocks-connector-for-apache-flink/pull/354).
You can enable it with the following configuration
```
sink.properties.format=json
sink.properties.compression=lz4_frame
```