### PR TITLE
shade starrocks-stream-load-sdk

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,26 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.4</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>com.starrocks:starrocks-stream-load-sdk</include>
+                                </includes>
+                            </artifactSet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <version>3.0.0</version>
                 <configuration>

--- a/src/assembly/development.xml
+++ b/src/assembly/development.xml
@@ -12,6 +12,9 @@
     <dependencySets>
         <dependencySet>
             <outputDirectory>share/java/starrocks-kafka-connector/</outputDirectory>
+            <excludes>
+                <exclude>com.starrocks:starrocks-stream-load-sdk</exclude>
+            </excludes>
         </dependencySet>
     </dependencySets>
 </assembly>

--- a/src/assembly/package.xml
+++ b/src/assembly/package.xml
@@ -18,6 +18,7 @@
                 <exclude>org.apache,kafka.connect.*</exclude>
                 <exclude>org.apache.kafka.connect.*</exclude>
                 <exclude>org.apache.kafka:connect-api</exclude>
+                <exclude>com.starrocks:starrocks-stream-load-sdk</exclude>
             </excludes>
         </dependencySet>
     </dependencySets>


### PR DESCRIPTION
**现象:**  在自建Apache Kafka 3.1.0的集群中，使用本connect同步数据到starrocks，报错：  
java.lang.NoClassDefFoundError: com/starrocks/data/load/stream/StreamLoadDataFormat
	at java.base/java.lang.Class.forName0(Native Method)
	at java.base/java.lang.Class.forName(Class.java:467)
	at org.apache.kafka.common.config.ConfigDef.parseType(ConfigDef.java:735)
	at org.apache.kafka.common.config.ConfigDef.parseValue(ConfigDef.java:490)
	at org.apache.kafka.common.config.ConfigDef.parse(ConfigDef.java:483)
	at org.apache.kafka.common.config.AbstractConfig.<init>(AbstractConfig.java:113)
	at org.apache.kafka.common.config.AbstractConfig.<init>(AbstractConfig.java:146)
	at org.apache.kafka.connect.runtime.TaskConfig.<init>(TaskConfig.java:51)
	at org.apache.kafka.connect.runtime.Worker.startTask(Worker.java:607)
	at org.apache.kafka.connect.runtime.Worker.startSinkTask(Worker.java:521)
	at org.apache.kafka.connect.runtime.standalone.StandaloneHerder.startTask(StandaloneHerder.java:392)
	at org.apache.kafka.connect.runtime.standalone.StandaloneHerder.createConnectorTasks(StandaloneHerder.java:385)
	at org.apache.kafka.connect.runtime.standalone.StandaloneHerder.createConnectorTasks(StandaloneHerder.java:379)
	at org.apache.kafka.connect.runtime.standalone.StandaloneHerder.updateConnectorTasks(StandaloneHerder.java:436)
	at org.apache.kafka.connect.runtime.standalone.StandaloneHerder.lambda$putConnectorConfig$2(StandaloneHerder.java:231)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:840)
Caused by: java.lang.ClassNotFoundException: com.starrocks.data.load.stream.StreamLoadDataFormat
	at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:445)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:592)
	at org.apache.kafka.connect.runtime.isolation.PluginClassLoader.loadClass(PluginClassLoader.java:136)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:525)
	... 21 mo

**错误原因:**  原因是org.apache.kafka.connect.runtime.isolation.PluginClassLoader实现问题，要求connector用到jar都必须在一个包里，否则无法加载class。com.starrocks.connector.kafka.StarRocksSinkConnector在starrocks-stream-load-sdk-1.0-20231130.060553-22-jar-with-dependencies.jar中，无法加载

**解决方案:**  将starrocks-stream-load-sdk-1.0-20231130.060553-22-jar-with-dependencies.jar的代码shade中当前代码中。

**测试结果:**  在自建Apache Kafka 3.1.0的集群中,测试成功