### PR TITLE
Support topic-mutating SMTs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>connect-api</artifactId>
-            <version>3.4.0</version>
+            <version>3.6.0</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
@@ -95,7 +95,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>connect-transforms</artifactId>
-            <version>3.4.0</version>
+            <version>3.6.0</version>
             <scope>provided</scope>
         </dependency>
 

--- a/src/main/java/com/starrocks/connector/kafka/StarRocksSinkTask.java
+++ b/src/main/java/com/starrocks/connector/kafka/StarRocksSinkTask.java
@@ -385,7 +385,6 @@ public class StarRocksSinkTask extends SinkTask  {
             LOG.info("commit: topic: " + topicPartition.topic() + ", partition: " + topicPartition.partition() + ", offset: " + topicPartitionOffset.get(topicPartition.topic()).get(topicPartition.partition()));
             synced.put(topicPartition, new OffsetAndMetadata(topicPartitionOffset.get(topicPartition.topic()).get(topicPartition.partition())));
         }
-        LOG.info("Precommit offset metas, received: {}, maintained: {}, returned: {}", new Object[] { offsets, this.topicPartitionOffset, this.synced });
         return synced;
     }
 


### PR DESCRIPTION
Certain SMT's change the name of the topic (e.g. a RegexRouter) such that the topicName in the `SinkRecord` does not equal the one in the `TopicPartition` in the `preCommit` method. Therefore, when using a RegexRouter in your configuration the offsets are never properly committed. This PR upgrades Kafka Connect to version 3.6 and makes minor changes to the 'put' method to support topic-mutating SMTs by storing the 'original' topic name rather than the mutated one. 

This PR fixes #33.