### PR TITLE
fix(validation): avoid 500 error when required config is missing during validation

### DIFF
--- a/src/main/java/com/starrocks/connector/kafka/StarRocksSinkConnector.java
+++ b/src/main/java/com/starrocks/connector/kafka/StarRocksSinkConnector.java
@@ -96,8 +96,10 @@ public class StarRocksSinkConnector extends SinkConnector {
         }
         Config result = super.validate(connectorConfigs);
         for (String config : StarRocksSinkConnectorConfig.mustRequiredConfigs) {
-            if (!connectorConfigs.containsKey(config)) {
-                throw new RuntimeException("You must specify" + config);
+            for (ConfigValue v : result.configValues()) {
+                if (v.name().equals(config) && !connectorConfigs.containsKey(config)) {
+                    v.addErrorMessage("You must specify " + config);
+                }
             }
         }
         return result;


### PR DESCRIPTION
When using the StarRocks Sink Connector with the Kafka Connect REST API for configuration validation, the request returns a `500` error instead of a `200` response with detailed validation results.

```bash
# Current Result
$ curl -X PUT http://localhost:8083/connector-plugins/com.starrocks.connector.kafka.StarRocksSinkConnector/config/validate \
    -H "Content-Type: application/json" \
    -d '{
        "connector.class": "com.starrocks.connector.kafka.StarRocksSinkConnector",
        "topics": "TopicName_StarRocksSinkConnector"
    }'
{"error_code":500,"message":"java.lang.RuntimeException: You must specifystarrocks.http.url"}
```

Other Kafka Connectors usually

- Return HTTP 200 even if required fields are missing.
- Include default values (if available).
- Provide detailed validation error messages for missing fields.

# Tested Result

kafka connect version: 3.9.0

It is too long, so I fold it.

<details><summary>Details</summary>
<p>

```json
{
  "name": "com.starrocks.connector.kafka.StarRocksSinkConnector",
  "error_count": 5,
  "groups": [
    "Common",
    "Transforms",
    "Predicates",
    "Error Handling",
    "config_group1"
  ],
  "configs": [
    {
      "definition": {
        "name": "name",
        "type": "STRING",
        "required": true,
        "default_value": null,
        "importance": "HIGH",
        "documentation": "Globally unique name to use for this connector.",
        "group": "Common",
        "width": "MEDIUM",
        "display_name": "Connector name",
        "dependents": [],
        "order": 1
      },
      "value": {
        "name": "name",
        "value": null,
        "recommended_values": [],
        "errors": [
          "Missing required configuration \"name\" which has no default value."
        ],
        "visible": true
      }
    },
    {
      "definition": {
        "name": "connector.class",
        "type": "STRING",
        "required": true,
        "default_value": null,
        "importance": "HIGH",
        "documentation": "Name or alias of the class for this connector. Must be a subclass of org.apache.kafka.connect.connector.Connector. If the connector is org.apache.kafka.connect.file.FileStreamSinkConnector, you can either specify this full name,  or use \"FileStreamSink\" or \"FileStreamSinkConnector\" to make the configuration a bit shorter",
        "group": "Common",
        "width": "LONG",
        "display_name": "Connector class",
        "dependents": [],
        "order": 2
      },
      "value": {
        "name": "connector.class",
        "value": "com.starrocks.connector.kafka.StarRocksSinkConnector",
        "recommended_values": [],
        "errors": [],
        "visible": true
      }
    },
    {
      "definition": {
        "name": "tasks.max",
        "type": "INT",
        "required": false,
        "default_value": "1",
        "importance": "HIGH",
        "documentation": "Maximum number of tasks to use for this connector.",
        "group": "Common",
        "width": "SHORT",
        "display_name": "Tasks max",
        "dependents": [],
        "order": 3
      },
      "value": {
        "name": "tasks.max",
        "value": "1",
        "recommended_values": [],
        "errors": [],
        "visible": true
      }
    },
    {
      "definition": {
        "name": "tasks.max.enforce",
        "type": "BOOLEAN",
        "required": false,
        "default_value": "true",
        "importance": "LOW",
        "documentation": "(Deprecated) Whether to enforce that the tasks.max property is respected by the connector. By default, connectors that generate too many tasks will fail, and existing sets of tasks that exceed the tasks.max property will also be failed. If this property is set to false, then connectors will be allowed to generate more than the maximum number of tasks, and existing sets of tasks that exceed the tasks.max property will be allowed to run. This property is deprecated and will be removed in an upcoming major release.",
        "group": "Common",
        "width": "SHORT",
        "display_name": "Enforce tasks max",
        "dependents": [],
        "order": 4
      },
      "value": {
        "name": "tasks.max.enforce",
        "value": "true",
        "recommended_values": [],
        "errors": [],
        "visible": true
      }
    },
    {
      "definition": {
        "name": "key.converter",
        "type": "CLASS",
        "required": false,
        "default_value": null,
        "importance": "LOW",
        "documentation": "Converter class used to convert between Kafka Connect format and the serialized form that is written to Kafka. This controls the format of the keys in messages written to or read from Kafka, and since this is independent of connectors it allows any connector to work with any serialization format. Examples of common formats include JSON and Avro.",
        "group": "Common",
        "width": "SHORT",
        "display_name": "Key converter class",
        "dependents": [],
        "order": 5
      },
      "value": {
        "name": "key.converter",
        "value": null,
        "recommended_values": [],
        "errors": [],
        "visible": true
      }
    },
    {
      "definition": {
        "name": "value.converter",
        "type": "CLASS",
        "required": false,
        "default_value": null,
        "importance": "LOW",
        "documentation": "Converter class used to convert between Kafka Connect format and the serialized form that is written to Kafka. This controls the format of the values in messages written to or read from Kafka, and since this is independent of connectors it allows any connector to work with any serialization format. Examples of common formats include JSON and Avro.",
        "group": "Common",
        "width": "SHORT",
        "display_name": "Value converter class",
        "dependents": [],
        "order": 6
      },
      "value": {
        "name": "value.converter",
        "value": null,
        "recommended_values": [],
        "errors": [],
        "visible": true
      }
    },
    {
      "definition": {
        "name": "header.converter",
        "type": "CLASS",
        "required": false,
        "default_value": null,
        "importance": "LOW",
        "documentation": "HeaderConverter class used to convert between Kafka Connect format and the serialized form that is written to Kafka. This controls the format of the header values in messages written to or read from Kafka, and since this is independent of connectors it allows any connector to work with any serialization format. Examples of common formats include JSON and Avro. By default, the SimpleHeaderConverter is used to serialize header values to strings and deserialize them by inferring the schemas.",
        "group": "Common",
        "width": "SHORT",
        "display_name": "Header converter class",
        "dependents": [],
        "order": 7
      },
      "value": {
        "name": "header.converter",
        "value": null,
        "recommended_values": [],
        "errors": [],
        "visible": true
      }
    },
    {
      "definition": {
        "name": "transforms",
        "type": "LIST",
        "required": false,
        "default_value": "",
        "importance": "LOW",
        "documentation": "Aliases for the transformations to be applied to records.",
        "group": "Transforms",
        "width": "LONG",
        "display_name": "Transforms",
        "dependents": [],
        "order": 8
      },
      "value": {
        "name": "transforms",
        "value": "",
        "recommended_values": [],
        "errors": [],
        "visible": true
      }
    },
    {
      "definition": {
        "name": "predicates",
        "type": "LIST",
        "required": false,
        "default_value": "",
        "importance": "LOW",
        "documentation": "Aliases for the predicates used by transformations.",
        "group": "Predicates",
        "width": "LONG",
        "display_name": "Predicates",
        "dependents": [],
        "order": 9
      },
      "value": {
        "name": "predicates",
        "value": "",
        "recommended_values": [],
        "errors": [],
        "visible": true
      }
    },
    {
      "definition": {
        "name": "config.action.reload",
        "type": "STRING",
        "required": false,
        "default_value": "restart",
        "importance": "LOW",
        "documentation": "The action that Connect should take on the connector when changes in external configuration providers result in a change in the connector's configuration properties. A value of 'none' indicates that Connect will do nothing. A value of 'restart' indicates that Connect should restart/reload the connector with the updated configuration properties.The restart may actually be scheduled in the future if the external configuration provider indicates that a configuration value will expire in the future.",
        "group": "Common",
        "width": "MEDIUM",
        "display_name": "Reload Action",
        "dependents": [],
        "order": 10
      },
      "value": {
        "name": "config.action.reload",
        "value": "restart",
        "recommended_values": [],
        "errors": [],
        "visible": true
      }
    },
    {
      "definition": {
        "name": "errors.retry.timeout",
        "type": "LONG",
        "required": false,
        "default_value": "0",
        "importance": "MEDIUM",
        "documentation": "The maximum duration in milliseconds that a failed operation will be reattempted. The default is 0, which means no retries will be attempted. Use -1 for infinite retries.",
        "group": "Error Handling",
        "width": "MEDIUM",
        "display_name": "Retry Timeout for Errors",
        "dependents": [],
        "order": 1
      },
      "value": {
        "name": "errors.retry.timeout",
        "value": "0",
        "recommended_values": [],
        "errors": [],
        "visible": true
      }
    },
    {
      "definition": {
        "name": "errors.retry.delay.max.ms",
        "type": "LONG",
        "required": false,
        "default_value": "60000",
        "importance": "MEDIUM",
        "documentation": "The maximum duration in milliseconds between consecutive retry attempts. Jitter will be added to the delay once this limit is reached to prevent thundering herd issues.",
        "group": "Error Handling",
        "width": "MEDIUM",
        "display_name": "Maximum Delay Between Retries for Errors",
        "dependents": [],
        "order": 2
      },
      "value": {
        "name": "errors.retry.delay.max.ms",
        "value": "60000",
        "recommended_values": [],
        "errors": [],
        "visible": true
      }
    },
    {
      "definition": {
        "name": "errors.tolerance",
        "type": "STRING",
        "required": false,
        "default_value": "none",
        "importance": "MEDIUM",
        "documentation": "Behavior for tolerating errors during connector operation. 'none' is the default value and signals that any error will result in an immediate connector task failure; 'all' changes the behavior to skip over problematic records.",
        "group": "Error Handling",
        "width": "SHORT",
        "display_name": "Error Tolerance",
        "dependents": [],
        "order": 3
      },
      "value": {
        "name": "errors.tolerance",
        "value": "none",
        "recommended_values": [],
        "errors": [],
        "visible": true
      }
    },
    {
      "definition": {
        "name": "errors.log.enable",
        "type": "BOOLEAN",
        "required": false,
        "default_value": "false",
        "importance": "MEDIUM",
        "documentation": "If true, write each error and the details of the failed operation and problematic record to the Connect application log. This is 'false' by default, so that only errors that are not tolerated are reported.",
        "group": "Error Handling",
        "width": "SHORT",
        "display_name": "Log Errors",
        "dependents": [],
        "order": 4
      },
      "value": {
        "name": "errors.log.enable",
        "value": "false",
        "recommended_values": [],
        "errors": [],
        "visible": true
      }
    },
    {
      "definition": {
        "name": "errors.log.include.messages",
        "type": "BOOLEAN",
        "required": false,
        "default_value": "false",
        "importance": "MEDIUM",
        "documentation": "Whether to include in the log the Connect record that resulted in a failure. For sink records, the topic, partition, offset, and timestamp will be logged. For source records, the key and value (and their schemas), all headers, and the timestamp, Kafka topic, Kafka partition, source partition, and source offset will be logged. This is 'false' by default, which will prevent record keys, values, and headers from being written to log files.",
        "group": "Error Handling",
        "width": "SHORT",
        "display_name": "Log Error Details",
        "dependents": [],
        "order": 5
      },
      "value": {
        "name": "errors.log.include.messages",
        "value": "false",
        "recommended_values": [],
        "errors": [],
        "visible": true
      }
    },
    {
      "definition": {
        "name": "topics",
        "type": "LIST",
        "required": false,
        "default_value": "",
        "importance": "HIGH",
        "documentation": "List of topics to consume, separated by commas",
        "group": "Common",
        "width": "LONG",
        "display_name": "Topics",
        "dependents": [],
        "order": 4
      },
      "value": {
        "name": "topics",
        "value": "TopicName_StarRocksSinkConnector",
        "recommended_values": [],
        "errors": [],
        "visible": true
      }
    },
    {
      "definition": {
        "name": "topics.regex",
        "type": "STRING",
        "required": false,
        "default_value": "",
        "importance": "HIGH",
        "documentation": "Regular expression giving topics to consume. Under the hood, the regex is compiled to a <code>java.util.regex.Pattern</code>. Only one of topics or topics.regex should be specified.",
        "group": "Common",
        "width": "LONG",
        "display_name": "Topics regex",
        "dependents": [],
        "order": 4
      },
      "value": {
        "name": "topics.regex",
        "value": "",
        "recommended_values": [],
        "errors": [],
        "visible": true
      }
    },
    {
      "definition": {
        "name": "errors.deadletterqueue.topic.name",
        "type": "STRING",
        "required": false,
        "default_value": "",
        "importance": "MEDIUM",
        "documentation": "The name of the topic to be used as the dead letter queue (DLQ) for messages that result in an error when processed by this sink connector, or its transformations or converters. The topic name is blank by default, which means that no messages are to be recorded in the DLQ.",
        "group": "Error Handling",
        "width": "MEDIUM",
        "display_name": "Dead Letter Queue Topic Name",
        "dependents": [],
        "order": 6
      },
      "value": {
        "name": "errors.deadletterqueue.topic.name",
        "value": "",
        "recommended_values": [],
        "errors": [],
        "visible": true
      }
    },
    {
      "definition": {
        "name": "errors.deadletterqueue.topic.replication.factor",
        "type": "SHORT",
        "required": false,
        "default_value": "3",
        "importance": "MEDIUM",
        "documentation": "Replication factor used to create the dead letter queue topic when it doesn't already exist.",
        "group": "Error Handling",
        "width": "MEDIUM",
        "display_name": "Dead Letter Queue Topic Replication Factor",
        "dependents": [],
        "order": 7
      },
      "value": {
        "name": "errors.deadletterqueue.topic.replication.factor",
        "value": "3",
        "recommended_values": [],
        "errors": [],
        "visible": true
      }
    },
    {
      "definition": {
        "name": "errors.deadletterqueue.context.headers.enable",
        "type": "BOOLEAN",
        "required": false,
        "default_value": "false",
        "importance": "MEDIUM",
        "documentation": "If true, add headers containing error context to the messages written to the dead letter queue. To avoid clashing with headers from the original record, all error context header keys, all error context header keys will start with <code>__connect.errors.</code>",
        "group": "Error Handling",
        "width": "MEDIUM",
        "display_name": "Enable Error Context Headers",
        "dependents": [],
        "order": 8
      },
      "value": {
        "name": "errors.deadletterqueue.context.headers.enable",
        "value": "false",
        "recommended_values": [],
        "errors": [],
        "visible": true
      }
    },
    {
      "definition": {
        "name": "starrocks.http.url",
        "type": "STRING",
        "required": false,
        "default_value": null,
        "importance": "HIGH",
        "documentation": "starrocks http url",
        "group": "config_group1",
        "width": "NONE",
        "display_name": "starrocks.http.url",
        "dependents": [],
        "order": 0
      },
      "value": {
        "name": "starrocks.http.url",
        "value": null,
        "recommended_values": [],
        "errors": [
          "You must specify starrocks.http.url"
        ],
        "visible": true
      }
    },
    {
      "definition": {
        "name": "starrocks.database.name",
        "type": "STRING",
        "required": false,
        "default_value": null,
        "importance": "HIGH",
        "documentation": "starrocks datbase name",
        "group": "config_group1",
        "width": "NONE",
        "display_name": "starrocks.database.name",
        "dependents": [],
        "order": 0
      },
      "value": {
        "name": "starrocks.database.name",
        "value": null,
        "recommended_values": [],
        "errors": [
          "You must specify starrocks.database.name"
        ],
        "visible": true
      }
    },
    {
      "definition": {
        "name": "sink.properties.format",
        "type": "STRING",
        "required": false,
        "default_value": null,
        "importance": "LOW",
        "documentation": "write to starrocks data format",
        "group": "config_group1",
        "width": "NONE",
        "display_name": "sink.properties.format",
        "dependents": [],
        "order": 0
      },
      "value": {
        "name": "sink.properties.format",
        "value": null,
        "recommended_values": [],
        "errors": [],
        "visible": true
      }
    },
    {
      "definition": {
        "name": "bufferflush.maxbytes",
        "type": "LONG",
        "required": false,
        "default_value": "67108864",
        "importance": "LOW",
        "documentation": "the size of a batch of data",
        "group": "config_group1",
        "width": "NONE",
        "display_name": "bufferflush.maxbytes",
        "dependents": [],
        "order": 0
      },
      "value": {
        "name": "bufferflush.maxbytes",
        "value": "67108864",
        "recommended_values": [],
        "errors": [],
        "visible": true
      }
    },
    {
      "definition": {
        "name": "connect.timeoutms",
        "type": "LONG",
        "required": false,
        "default_value": "100",
        "importance": "LOW",
        "documentation": "timeout period for connecting to load-url",
        "group": "config_group1",
        "width": "NONE",
        "display_name": "connect.timeoutms",
        "dependents": [],
        "order": 0
      },
      "value": {
        "name": "connect.timeoutms",
        "value": "100",
        "recommended_values": [],
        "errors": [],
        "visible": true
      }
    },
    {
      "definition": {
        "name": "starrocks.username",
        "type": "STRING",
        "required": false,
        "default_value": null,
        "importance": "HIGH",
        "documentation": "starrocks username",
        "group": "config_group1",
        "width": "NONE",
        "display_name": "starrocks.username",
        "dependents": [],
        "order": 0
      },
      "value": {
        "name": "starrocks.username",
        "value": null,
        "recommended_values": [],
        "errors": [
          "You must specify starrocks.username"
        ],
        "visible": true
      }
    },
    {
      "definition": {
        "name": "starrocks.password",
        "type": "STRING",
        "required": false,
        "default_value": null,
        "importance": "HIGH",
        "documentation": "starrocks password",
        "group": "config_group1",
        "width": "NONE",
        "display_name": "starrocks.password",
        "dependents": [],
        "order": 0
      },
      "value": {
        "name": "starrocks.password",
        "value": null,
        "recommended_values": [],
        "errors": [
          "You must specify starrocks.password"
        ],
        "visible": true
      }
    },
    {
      "definition": {
        "name": "bufferflush.intervalms",
        "type": "LONG",
        "required": false,
        "default_value": "1000",
        "importance": "LOW",
        "documentation": "the interval at which data is sent in bulk to starrocks",
        "group": "config_group1",
        "width": "NONE",
        "display_name": "bufferflush.intervalms",
        "dependents": [],
        "order": 0
      },
      "value": {
        "name": "bufferflush.intervalms",
        "value": "1000",
        "recommended_values": [],
        "errors": [],
        "visible": true
      }
    },
    {
      "definition": {
        "name": "starrocks.topic2table.map",
        "type": "STRING",
        "required": false,
        "default_value": null,
        "importance": "LOW",
        "documentation": "a mapping between the topic name and the table name",
        "group": "config_group1",
        "width": "NONE",
        "display_name": "starrocks.topic2table.map",
        "dependents": [],
        "order": 0
      },
      "value": {
        "name": "starrocks.topic2table.map",
        "value": null,
        "recommended_values": [],
        "errors": [],
        "visible": true
      }
    },
    {
      "definition": {
        "name": "sink.maxretries",
        "type": "LONG",
        "required": false,
        "default_value": "3",
        "importance": "LOW",
        "documentation": "number of Stream Load retries after a stream load failure",
        "group": "config_group1",
        "width": "NONE",
        "display_name": "sink.maxretries",
        "dependents": [],
        "order": 0
      },
      "value": {
        "name": "sink.maxretries",
        "value": "3",
        "recommended_values": [],
        "errors": [],
        "visible": true
      }
    }
  ]
}
```

</p>
</details> 

Also, I tested it on [landoop/kafka-connect-ui](https://hub.docker.com/r/landoop/kafka-connect-ui).

<details><summary>Details</summary>
<p>

<img width="697" height="636" alt="image" src="https://github.com/user-attachments/assets/f97b13c4-e65f-48bd-958f-92fcd2a66ba8" />

</p>
</details> 




# Related Issue

https://github.com/StarRocks/starrocks-connector-for-kafka/issues/48