### PR TITLE
chore: fix typo of `STARROCKS_DATABASE_NAME` connector property

### DIFF
--- a/src/main/java/com/starrocks/connector/kafka/StarRocksSinkConnectorConfig.java
+++ b/src/main/java/com/starrocks/connector/kafka/StarRocksSinkConnectorConfig.java
@@ -88,7 +88,7 @@ public class StarRocksSinkConnectorConfig {
                         null,
                         new ConfigDef.NonEmptyString(),
                         ConfigDef.Importance.HIGH,
-                        "starrocks datbase name",
+                        "starrocks database name",
                         CONFIG_GROUP_1,
                         0,
                         ConfigDef.Width.NONE,


### PR DESCRIPTION
Hello, team!

I found a small typo in the Kafka Connect property description and fixed it.

Thanks!