### PR TITLE
Support Debezium Envelope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0.5</version>
 
     <properties>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -125,7 +125,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>connect-api</artifactId>
-            <version>3.6.0</version>
+            <version>4.1.1</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
@@ -154,7 +154,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>connect-transforms</artifactId>
-            <version>3.6.0</version>
+            <version>4.1.1</version>
             <scope>provided</scope>
         </dependency>
 
@@ -204,8 +204,13 @@
 
         <dependency>
             <groupId>io.debezium</groupId>
-            <artifactId>debezium-core</artifactId>
-            <version>1.8.1.Final</version>
+            <artifactId>debezium-connector-common</artifactId>
+            <version>3.5.0.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>io.debezium</groupId>
+            <artifactId>debezium-connect-plugins</artifactId>
+            <version>3.5.0.Final</version>
         </dependency>
 
     </dependencies>

--- a/src/main/java/com/starrocks/connector/kafka/StarRocksSinkConnectorConfig.java
+++ b/src/main/java/com/starrocks/connector/kafka/StarRocksSinkConnectorConfig.java
@@ -62,6 +62,16 @@ public class StarRocksSinkConnectorConfig {
     // This configuration controls the number of failed retries. The default value is 3. -1 indicates unlimited retry.
     public static final String SINK_MAXRETRIES = "sink.maxretries";
 
+    // The envelope format of incoming Kafka records.
+    // Supported values: `none` (default), `debezium`.
+    // When set to `debezium`, records are expected to be in Debezium CDC envelope format
+    // and are unwrapped before being written to StarRocks.
+    public static final String ENVELOPE = "starrocks.envelope";
+
+    // Specifies whether the connector processes DELETE or tombstone events
+    // and removes the corresponding row from the database
+    public static final String DELETE_ENABLE = "starrocks.delete.enabled";
+
     public static final String[] mustRequiredConfigs = {
             STARROCKS_LOAD_URL,
             STARROCKS_DATABASE_NAME,
@@ -181,6 +191,25 @@ public class StarRocksSinkConnectorConfig {
                         0,
                         ConfigDef.Width.NONE,
                         SINK_MAXRETRIES
+                ).define(
+                        ENVELOPE, ConfigDef.Type.STRING, "none",
+                        ConfigDef.ValidString.in("none", "debezium"),
+                        ConfigDef.Importance.MEDIUM,
+                        "envelope format of incoming records; 'none' (default) or 'debezium'",
+                        CONFIG_GROUP_1,
+                        0,
+                        ConfigDef.Width.NONE, ENVELOPE
+                )
+                .define(
+                        DELETE_ENABLE, ConfigDef.Type.BOOLEAN, false,
+                        null,
+                        ConfigDef.Importance.MEDIUM,
+                        "Specifies whether the connector processes DELETE or tombstone events and " +
+                                "removes the corresponding row from the database. " +
+                                "Enable option requires target table is PRIMARY KEY table.",
+                        CONFIG_GROUP_1,
+                        0,
+                        ConfigDef.Width.NONE, DELETE_ENABLE
                 );
     }
 }

--- a/src/main/java/com/starrocks/connector/kafka/StarRocksSinkTask.java
+++ b/src/main/java/com/starrocks/connector/kafka/StarRocksSinkTask.java
@@ -20,21 +20,9 @@
 
 package com.starrocks.connector.kafka;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
-
-import org.apache.kafka.clients.consumer.OffsetAndMetadata;
-import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.connect.errors.DataException;
-import org.apache.kafka.connect.sink.SinkRecord;
-import org.apache.kafka.connect.sink.SinkTask;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.fasterxml.jackson.databind.JsonNode;
+import com.starrocks.connector.kafka.envelope.DebeziumEnvelope;
+import com.starrocks.connector.kafka.envelope.NoopEnvelope;
 import com.starrocks.connector.kafka.json.DecimalFormat;
 import com.starrocks.connector.kafka.json.JsonConverter;
 import com.starrocks.connector.kafka.json.JsonConverterConfig;
@@ -42,6 +30,19 @@ import com.starrocks.data.load.stream.StreamLoadDataFormat;
 import com.starrocks.data.load.stream.properties.StreamLoadProperties;
 import com.starrocks.data.load.stream.properties.StreamLoadTableProperties;
 import com.starrocks.data.load.stream.v2.StreamLoadManagerV2;
+import io.debezium.transforms.ExtractNewRecordStateConfigDefinition.DeleteTombstoneHandling;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.apache.kafka.connect.sink.SinkTask;
+import org.apache.kafka.connect.transforms.Transformation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+
+import static io.debezium.transforms.ExtractNewRecordStateConfigDefinition.HANDLE_TOMBSTONE_DELETES;
 
 
 //  Please reference to: https://docs.confluent.io/platform/7.4/connect/javadocs/javadoc/org/apache/kafka/connect/sink/SinkTask.html
@@ -59,12 +60,13 @@ import com.starrocks.data.load.stream.v2.StreamLoadManagerV2;
 //    4. Partition Rebalancing: Occasionally, Connect will need to change the assignment of this task. When this happens, the currently assigned partitions will be closed with close(Collection) and the new assignment will be opened using open(Collection).
 //    5. Shutdown: When the task needs to be shutdown, Connect will close active partitions (if there are any) and stop the task using stop()
 
-public class StarRocksSinkTask extends SinkTask  {
+public class StarRocksSinkTask extends SinkTask {
 
     enum SinkType {
         CSV,
         JSON
     }
+
     private SinkType sinkType;
     private static final Logger LOG = LoggerFactory.getLogger(StarRocksSinkTask.class);
     private StreamLoadManagerV2 loadManager;
@@ -80,6 +82,7 @@ public class StarRocksSinkTask extends SinkTask  {
     private long maxRetryTimes;
     private long retryCount = 0;
     private Throwable sdkException;
+    private Transformation<SinkRecord> transformation;
 
     private long buffMaxbytes;
     private long bufferFlushInterval;
@@ -207,6 +210,18 @@ public class StarRocksSinkTask extends SinkTask  {
         topic2Table = getTopicToTableMap(props);
         jsonConverter = createJsonConverter();
         maxRetryTimes = Long.parseLong(props.getOrDefault(StarRocksSinkConnectorConfig.SINK_MAXRETRIES, "3"));
+        transformation = new NoopEnvelope<>();
+        String envelope = props.getOrDefault(StarRocksSinkConnectorConfig.ENVELOPE, "none").toLowerCase();
+        String deleteEnabled = props.getOrDefault(StarRocksSinkConnectorConfig.DELETE_ENABLE, "false").toLowerCase();
+        if ("debezium".equals(envelope)) {
+            transformation = new DebeziumEnvelope<>();
+            if (deleteEnabled.equals("true")) {
+                props.put(HANDLE_TOMBSTONE_DELETES.name(), DeleteTombstoneHandling.REWRITE.getValue());
+            } else {
+                props.put(HANDLE_TOMBSTONE_DELETES.name(), DeleteTombstoneHandling.DROP.getValue());
+            }
+            transformation.configure(props);
+        }
         LOG.info("Starrocks sink task started. version is " + Util.VERSION);
     }
 
@@ -282,7 +297,7 @@ public class StarRocksSinkTask extends SinkTask  {
         if (maxRetryTimes != -1) {
             if (retryCount > maxRetryTimes) {
                 LOG.error("Starrocks Put failure " + retryCount + " times, which bigger than maxRetryTimes "
-                            + maxRetryTimes + ", sink task will be stopped");
+                        + maxRetryTimes + ", sink task will be stopped");
                 assert sdkException != null;
                 LOG.error("Error message is ", sdkException);
                 throw new RuntimeException(sdkException);
@@ -299,6 +314,12 @@ public class StarRocksSinkTask extends SinkTask  {
                 firstRecord = record;
             }
             LOG.debug("Received record: " + record.toString());
+
+            record = transformation.apply(record);
+            if (record == null) {
+                LOG.debug("Record filtered out by transformation");
+                continue;
+            }
 
             String topic = record.topic();
             // The sdk does not provide the ability to clean up exceptions, that is to say, according to the current implementation of the SDK,
@@ -317,7 +338,7 @@ public class StarRocksSinkTask extends SinkTask  {
                 currentBufferBytes += row.getBytes().length;
             } catch (Exception writeException) {
                 LOG.error("Starrocks Put error: " + writeException.getMessage() +
-                          " topic, partition, offset is " + topic + ", " + record.kafkaPartition() + ", " + record.kafkaOffset());
+                        " topic, partition, offset is " + topic + ", " + record.kafkaPartition() + ", " + record.kafkaOffset());
                 writeException.printStackTrace();
                 occurException = true;
                 e = writeException;
@@ -327,14 +348,14 @@ public class StarRocksSinkTask extends SinkTask  {
 
         if (occurException && e != null) {
             LOG.info("Starrocks Put occurs exception, Err {} currentBufferBytes {} recordRange [{}:{}-{}:{}] cost {}ms",
-                    e.getMessage(), currentBufferBytes, 
+                    e.getMessage(), currentBufferBytes,
                     firstRecord == null ? null : firstRecord.kafkaPartition(),
                     firstRecord == null ? null : firstRecord.kafkaOffset(),
                     record == null ? null : record.kafkaPartition(),
                     record == null ? null : record.kafkaOffset(), System.currentTimeMillis() - start);
         } else {
             LOG.info("Starrocks Put success, currentBufferBytes {} recordRange [{}:{}-{}:{}] cost {}ms",
-                    currentBufferBytes, 
+                    currentBufferBytes,
                     firstRecord == null ? null : firstRecord.kafkaPartition(),
                     firstRecord == null ? null : firstRecord.kafkaOffset(),
                     record == null ? null : record.kafkaPartition(),
@@ -348,7 +369,7 @@ public class StarRocksSinkTask extends SinkTask  {
         // return previous offset when buffer size and flush interval are not reached
         if (currentBufferBytes < buffMaxbytes && System.currentTimeMillis() - lastFlushTime < bufferFlushInterval) {
             LOG.info("Starrocks skip preCommit currentBufferBytes {} less than buffMaxbytes {}"
-                    + " or SinceLastFlushTime {} less than bufferFlushInterval {}",
+                            + " or SinceLastFlushTime {} less than bufferFlushInterval {}",
                     currentBufferBytes, buffMaxbytes, System.currentTimeMillis() - lastFlushTime, bufferFlushInterval);
             return Collections.emptyMap();
         }

--- a/src/main/java/com/starrocks/connector/kafka/envelope/DebeziumEnvelope.java
+++ b/src/main/java/com/starrocks/connector/kafka/envelope/DebeziumEnvelope.java
@@ -1,0 +1,38 @@
+package com.starrocks.connector.kafka.envelope;
+
+import io.debezium.transforms.ConnectRecordUtil;
+import io.debezium.transforms.ExtractNewRecordState;
+import io.debezium.transforms.ExtractNewRecordStateConfigDefinition.DeleteTombstoneHandling;
+import io.debezium.transforms.extractnewstate.DefaultDeleteHandlingStrategy;
+import org.apache.kafka.connect.connector.ConnectRecord;
+
+import java.util.Map;
+
+import static io.debezium.transforms.ExtractNewRecordStateConfigDefinition.HANDLE_TOMBSTONE_DELETES;
+import static io.debezium.transforms.ExtractNewRecordStateConfigDefinition.REPLACE_NULL_WITH_DEFAULT;
+
+public class DebeziumEnvelope<R extends ConnectRecord<R>> extends ExtractNewRecordState<R> {
+    @Override
+    public void configure(Map<String, ?> configs) {
+        super.configure(configs);
+
+        // override the default delete handling strategy
+        // by swapping `__deleted` out for `__op`
+        DeleteTombstoneHandling deleteTombstoneHandling = DeleteTombstoneHandling.parse(config.getString(HANDLE_TOMBSTONE_DELETES));
+        extractRecordStrategy = new DeleteHandlingStrategy<>(
+                deleteTombstoneHandling,
+                config.getBoolean(REPLACE_NULL_WITH_DEFAULT)
+        );
+    }
+
+    private static class DeleteHandlingStrategy<R extends ConnectRecord<R>> extends DefaultDeleteHandlingStrategy<R> {
+        public static final String OP_FIELD_NAME = "__op";
+
+        public DeleteHandlingStrategy(DeleteTombstoneHandling deleteTombstoneHandling, boolean replaceNullWithDefault) {
+            super(deleteTombstoneHandling, replaceNullWithDefault);
+
+            removedDelegate = ConnectRecordUtil.insertStaticValueDelegate(OP_FIELD_NAME, "1", replaceNullWithDefault);
+            updatedDelegate = ConnectRecordUtil.insertStaticValueDelegate(OP_FIELD_NAME, "0", replaceNullWithDefault);
+        }
+    }
+}

--- a/src/main/java/com/starrocks/connector/kafka/envelope/NoopEnvelope.java
+++ b/src/main/java/com/starrocks/connector/kafka/envelope/NoopEnvelope.java
@@ -1,0 +1,27 @@
+package com.starrocks.connector.kafka.envelope;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.transforms.Transformation;
+
+import java.util.Map;
+
+public class NoopEnvelope<R extends ConnectRecord<R>> implements Transformation<R> {
+    @Override
+    public R apply(R record) {
+        return record;
+    }
+
+    @Override
+    public ConfigDef config() {
+        return new ConfigDef();
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public void configure(Map<String, ?> configs) {
+    }
+}


### PR DESCRIPTION
Currently, in order to consume Debezium CDC from Kafka to StarRocks, we need to configure bunch of `transforms` like this:
```properties
transforms=addfield,unwrap
transforms.addfield.type=com.starrocks.connector.kafka.transforms.AddOpFieldForDebeziumRecord
transforms.unwrap.type=io.debezium.transforms.ExtractNewRecordState
transforms.unwrap.drop.tombstones=true
transforms.unwrap.delete.handling.mode=rewrite
```
This PR simplify this setup by automatic extract record state when `starrocks.envelope=debezium`. It's similar Debezium sink connector for [JDBC](https://debezium.io/documentation/reference/3.5/connectors/jdbc.html) and [MongoDB](https://debezium.io/documentation/reference/3.5/connectors/mongodb-sink.html).

**Note**: StarRocks recently support `Debezium JSON` format naively in StarRocks/starrocks#71537. Why this PR still relevant:
* Unwraps Debezium envelopes before transfer reduce lots network bandwidth.
* Second, it makes Debezium CDC available to users on older StarRocks versions who cannot upgrade immediately.
* Third, it fits naturally into organizations that already operate a Kafka Connect cluster with established monitoring, alerting, and secret management, avoiding a second ingestion path.
* Fourth, by sitting inside the Kafka Connect ecosystem, the connector transparently supports serialization formats beyond JSON — including Protobuf, Apicurio Registry, and AWS Glue Schema Registry — without any changes required on the StarRocks server side.